### PR TITLE
Add get bindings and class metadata to core

### DIFF
--- a/packages/iocuak-core/CHANGELOG.md
+++ b/packages/iocuak-core/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `BindingService`.
 - Added `BindingServiceImplementation`.
+- Added `ContainerModule`.
+- Added `ContainerModuleClassMetadata`.
+- Added `ContainerModuleFactoryMetadata`.
+- Added `ContainerModuleMetadata`.
 - Added `ContainerRequestService`.
 - Added `ContainerRequestServiceImplementation`.
 - Added `ContainerSingletonService`.
@@ -31,6 +35,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `createInstance`.
 - Added `createInstanceFromBinding`.
 - Added `createInstancesByTag`.
+- Added `getBindingMetadata`.
+- Added `getBindingOrThrow`.
+- Added `getClassMetadata`.
 - Added `getDependencies`.
 - Added `loadContainerModule`.
 - Added `TaskContext`.

--- a/packages/iocuak-core/package.json
+++ b/packages/iocuak-core/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://github.com/cuaklabs/iocuak/tree/master/packages/iocuak-core#readme",
   "dependencies": {
     "@cuaklabs/iocuak-common": "workspace:../iocuak-common",
-    "@cuaklabs/iocuak-models": "workspace:../iocuak-models"
+    "@cuaklabs/iocuak-models": "workspace:../iocuak-models",
+    "@cuaklabs/iocuak-reflect-metadata-utils": "workspace:../iocuak-reflect-metadata-utils"
   },
   "devDependencies": {
     "rimraf": "3.0.2",

--- a/packages/iocuak-core/src/binding/utils/domain/getBindingMetadata.spec.ts
+++ b/packages/iocuak-core/src/binding/utils/domain/getBindingMetadata.spec.ts
@@ -1,0 +1,33 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@cuaklabs/iocuak-reflect-metadata-utils');
+
+import { Newable } from '@cuaklabs/iocuak-common';
+import { bindingReflectKey } from '@cuaklabs/iocuak-models';
+import { getReflectMetadata } from '@cuaklabs/iocuak-reflect-metadata-utils';
+
+import { getBindingMetadata } from './getBindingMetadata';
+
+describe(getBindingMetadata.name, () => {
+  describe('when called', () => {
+    let typeFixture: Newable;
+
+    beforeAll(() => {
+      typeFixture = class {};
+
+      getBindingMetadata(typeFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getReflectMetadata()', () => {
+      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(getReflectMetadata).toHaveBeenCalledWith(
+        typeFixture,
+        bindingReflectKey,
+      );
+    });
+  });
+});

--- a/packages/iocuak-core/src/binding/utils/domain/getBindingMetadata.ts
+++ b/packages/iocuak-core/src/binding/utils/domain/getBindingMetadata.ts
@@ -1,0 +1,14 @@
+import { Newable } from '@cuaklabs/iocuak-common';
+import { bindingReflectKey, TypeBinding } from '@cuaklabs/iocuak-models';
+import { getReflectMetadata } from '@cuaklabs/iocuak-reflect-metadata-utils';
+
+export function getBindingMetadata<TInstance, TArgs extends unknown[]>(
+  type: Newable<TInstance, TArgs>,
+): TypeBinding<TInstance, TArgs> | undefined {
+  const binding: TypeBinding<TInstance, TArgs> | undefined = getReflectMetadata(
+    type,
+    bindingReflectKey,
+  );
+
+  return binding;
+}

--- a/packages/iocuak-core/src/binding/utils/domain/getBindingOrThrow.spec.ts
+++ b/packages/iocuak-core/src/binding/utils/domain/getBindingOrThrow.spec.ts
@@ -2,12 +2,13 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import * as jestMock from 'jest-mock';
 
-jest.mock('@cuaklabs/iocuak-models');
+jest.mock('./getBindingMetadata');
 
 import { Newable } from '@cuaklabs/iocuak-common';
-import { getBindingMetadata, TypeBinding } from '@cuaklabs/iocuak-models';
+import { TypeBinding } from '@cuaklabs/iocuak-models';
 
 import { TypeBindingFixtures } from '../../fixtures/domain/TypeBindingFixtures';
+import { getBindingMetadata } from './getBindingMetadata';
 import { getBindingOrThrow } from './getBindingOrThrow';
 
 describe(getBindingOrThrow.name, () => {

--- a/packages/iocuak-core/src/binding/utils/domain/getBindingOrThrow.ts
+++ b/packages/iocuak-core/src/binding/utils/domain/getBindingOrThrow.ts
@@ -1,5 +1,7 @@
 import { Newable } from '@cuaklabs/iocuak-common';
-import { getBindingMetadata, TypeBinding } from '@cuaklabs/iocuak-models';
+import { TypeBinding } from '@cuaklabs/iocuak-models';
+
+import { getBindingMetadata } from './getBindingMetadata';
 
 export function getBindingOrThrow<TInstance, TArgs extends unknown[]>(
   type: Newable<TInstance, TArgs>,

--- a/packages/iocuak-core/src/classMetadata/utils/getClassMetadata.spec.ts
+++ b/packages/iocuak-core/src/classMetadata/utils/getClassMetadata.spec.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import * as jestMock from 'jest-mock';
+
+jest.mock('@cuaklabs/iocuak-models');
+jest.mock('@cuaklabs/iocuak-reflect-metadata-utils');
+
+import { Newable } from '@cuaklabs/iocuak-common';
+import {
+  ClassMetadata,
+  classMetadataReflectKey,
+  getDefaultClassMetadata,
+} from '@cuaklabs/iocuak-models';
+import { getReflectMetadata } from '@cuaklabs/iocuak-reflect-metadata-utils';
+
+import { ClassMetadataFixtures } from '../fixtures/domain/ClassMetadataFixtures';
+import { getClassMetadata } from './getClassMetadata';
+
+describe('.getClassMetadata()', () => {
+  describe('when called, and getReflectMetadata returns undefined', () => {
+    let typeFixture: Newable;
+    let classMetadataFixture: ClassMetadata;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      typeFixture = class {};
+      classMetadataFixture = {
+        constructorArguments: [],
+        properties: new Map(),
+      };
+
+      (
+        getReflectMetadata as jestMock.Mock<typeof getReflectMetadata>
+      ).mockReturnValueOnce(undefined);
+
+      (
+        getDefaultClassMetadata as jestMock.Mock<typeof getDefaultClassMetadata>
+      ).mockReturnValueOnce(classMetadataFixture);
+
+      result = getClassMetadata(typeFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getReflectMetadata()', () => {
+      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(getReflectMetadata).toHaveBeenCalledWith(
+        typeFixture,
+        classMetadataReflectKey,
+      );
+    });
+
+    it('should call getDefaultClassMetadata', () => {
+      expect(getDefaultClassMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return ClassMetadata', () => {
+      expect(result).toBe(classMetadataFixture);
+    });
+  });
+
+  describe('when called, and getReflectMetadata returns ClassMetadata', () => {
+    let typeFixture: Newable;
+    let classMetadataFixture: ClassMetadata;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      typeFixture = class {};
+      classMetadataFixture =
+        ClassMetadataFixtures.withConstructorArgumentsServiceAndPropertiesService;
+
+      (
+        getReflectMetadata as jestMock.Mock<typeof getReflectMetadata>
+      ).mockReturnValueOnce(classMetadataFixture);
+
+      result = getClassMetadata(typeFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getReflectMetadata()', () => {
+      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(getReflectMetadata).toHaveBeenCalledWith(
+        typeFixture,
+        classMetadataReflectKey,
+      );
+    });
+
+    it('should return ClassMetadata', () => {
+      expect(result).toStrictEqual(classMetadataFixture);
+    });
+  });
+});

--- a/packages/iocuak-core/src/classMetadata/utils/getClassMetadata.ts
+++ b/packages/iocuak-core/src/classMetadata/utils/getClassMetadata.ts
@@ -1,0 +1,29 @@
+import { Newable } from '@cuaklabs/iocuak-common';
+import {
+  ClassMetadata,
+  classMetadataReflectKey,
+  getDefaultClassMetadata,
+} from '@cuaklabs/iocuak-models';
+import { getReflectMetadata } from '@cuaklabs/iocuak-reflect-metadata-utils';
+
+export function getClassMetadata<TInstance, TArgs extends unknown[]>(
+  type: Newable<TInstance, TArgs>,
+): ClassMetadata {
+  const classMetadata: ClassMetadata | undefined = getReflectMetadata(
+    type,
+    classMetadataReflectKey,
+  );
+
+  let classMetadataClone: ClassMetadata;
+
+  if (classMetadata === undefined) {
+    classMetadataClone = getDefaultClassMetadata();
+  } else {
+    classMetadataClone = {
+      constructorArguments: [...classMetadata.constructorArguments],
+      properties: new Map(classMetadata.properties),
+    };
+  }
+
+  return classMetadataClone;
+}

--- a/packages/iocuak-core/src/index.ts
+++ b/packages/iocuak-core/src/index.ts
@@ -1,9 +1,16 @@
 import { BindingService } from './binding/services/domain/BindingService';
 import { BindingServiceImplementation } from './binding/services/domain/BindingServiceImplementation';
+import { getBindingMetadata } from './binding/utils/domain/getBindingMetadata';
+import { getBindingOrThrow } from './binding/utils/domain/getBindingOrThrow';
+import { getClassMetadata } from './classMetadata/utils/getClassMetadata';
 import { ContainerRequestService } from './container/services/domain/ContainerRequestService';
 import { ContainerRequestServiceImplementation } from './container/services/domain/ContainerRequestServiceImplementation';
 import { ContainerSingletonService } from './container/services/domain/ContainerSingletonService';
 import { ContainerSingletonServiceImplementation } from './container/services/domain/ContainerSingletonServiceImplementation';
+import { ContainerModule } from './containerModule/models/domain/ContainerModule';
+import { ContainerModuleClassMetadata } from './containerModuleMetadata/models/domain/ContainerModuleClassMetadata';
+import { ContainerModuleFactoryMetadata } from './containerModuleMetadata/models/domain/ContainerModuleFactoryMetadata';
+import { ContainerModuleMetadata } from './containerModuleMetadata/models/domain/ContainerModuleMetadata';
 import { createInstance } from './task/actions/domain/createInstance';
 import { createInstanceFromBinding } from './task/actions/domain/createInstanceFromBinding';
 import { createInstancesByTag } from './task/actions/domain/createInstancesByTag';
@@ -15,6 +22,10 @@ import { TaskContextServices } from './task/models/domain/TaskContextServices';
 
 export type {
   BindingService,
+  ContainerModule,
+  ContainerModuleClassMetadata,
+  ContainerModuleFactoryMetadata,
+  ContainerModuleMetadata,
   ContainerRequestService,
   ContainerSingletonService,
   TaskContext,
@@ -29,6 +40,9 @@ export {
   createInstance,
   createInstanceFromBinding,
   createInstancesByTag,
+  getBindingMetadata,
+  getBindingOrThrow,
+  getClassMetadata,
   getDependencies,
   loadContainerModule,
 };

--- a/packages/iocuak-core/src/task/actions/domain/createInstanceInTransientScope.spec.ts
+++ b/packages/iocuak-core/src/task/actions/domain/createInstanceInTransientScope.spec.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import * as jestMock from 'jest-mock';
 
-jest.mock('@cuaklabs/iocuak-models');
+jest.mock('../../../classMetadata/utils/getClassMetadata');
 
 import { ServiceId } from '@cuaklabs/iocuak-common';
 import {
@@ -10,11 +10,11 @@ import {
   BindingScope,
   BindingType,
   ClassMetadata,
-  getClassMetadata,
 } from '@cuaklabs/iocuak-models';
 
 import { TypeBindingFixtures } from '../../../binding/fixtures/domain/TypeBindingFixtures';
 import { ClassMetadataFixtures } from '../../../classMetadata/fixtures/domain/ClassMetadataFixtures';
+import { getClassMetadata } from '../../../classMetadata/utils/getClassMetadata';
 import { ServiceDependencies } from '../../models/domain/ServiceDependencies';
 import { TaskContext } from '../../models/domain/TaskContext';
 import { TaskContextActions } from '../../models/domain/TaskContextActions';

--- a/packages/iocuak-core/src/task/actions/domain/createInstanceInTransientScope.ts
+++ b/packages/iocuak-core/src/task/actions/domain/createInstanceInTransientScope.ts
@@ -1,9 +1,6 @@
-import {
-  TypeBinding,
-  ClassMetadata,
-  getClassMetadata,
-} from '@cuaklabs/iocuak-models';
+import { TypeBinding, ClassMetadata } from '@cuaklabs/iocuak-models';
 
+import { getClassMetadata } from '../../../classMetadata/utils/getClassMetadata';
 import { ServiceDependencies } from '../../models/domain/ServiceDependencies';
 import { TaskContext } from '../../models/domain/TaskContext';
 


### PR DESCRIPTION
### Added
- Added `ContainerModuleClassMetadata`.
- Added `ContainerModuleFactoryMetadata`.
- Added `ContainerModuleMetadata`.
- Added `getBindingMetadata`.
- Added `getBindingOrThrow`.
- Added `getClassMetadata`.