### PR TITLE
Update renovate config to not automerge typescript

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,8 @@
     {
       "groupName": "auto merge on patch or minor",
       "automerge": true,
-      "matchUpdateTypes": ["patch", "minor"]
+      "matchUpdateTypes": ["patch", "minor"],
+      "excludePackageNames": ["typescript"]
     }
   ]
 }


### PR DESCRIPTION
### Changed
- Update renovate config to not automerge `typescript` updates