### PR TITLE
Update eslint import ts resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@typescript-eslint/eslint-plugin": "5.40.0",
     "@typescript-eslint/parser": "5.40.0",
     "eslint": "8.25.0",
+    "eslint-import-resolver-typescript": "3.5.1",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "27.1.2",
     "eslint-plugin-prettier": "4.2.1",

--- a/packages/eslint-config-iocuak/index.js
+++ b/packages/eslint-config-iocuak/index.js
@@ -146,6 +146,12 @@ module.exports = {
       },
     ],
   },
+  settings: {
+    'import/resolver': {
+      node: true,
+      typescript: true,
+    },
+  },
   overrides: [
     {
       files: ['**/*.spec.ts'],


### PR DESCRIPTION
### Changed
- Updated eslint import resolver to rely on `eslint-import-resolver-typescript`.