### PR TITLE
Fix set-output deprecations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -52,7 +52,7 @@ jobs:
 
       - name: Get affected packages
         id: get-affected-packages
-        run: echo "::set-output name=packages::$(pnpm exec iocuak-get-affected-projects origin/${{github.base_ref}})"
+        run: echo "packages=$(pnpm exec iocuak-get-affected-projects origin/${{github.base_ref}})" >> $GITHUB_OUTPUT
 
       - name: Compile source files
         run: pnpm run build:all
@@ -63,7 +63,7 @@ jobs:
       - name: Get current git commit hash
         id: get-git-commit-hash
         run: |
-          echo "::set-output name=gitCommitHash::$(git rev-parse HEAD)"
+          echo "gitCommitHash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: ts-build-cache
@@ -101,7 +101,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -117,7 +117,7 @@ jobs:
       - name: Get current git commit hash
         id: get-git-commit-hash
         run: |
-          echo "::set-output name=gitCommitHash::$(git rev-parse HEAD)"
+          echo "gitCommitHash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: ts-build-cache
@@ -188,7 +188,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
@@ -204,7 +204,7 @@ jobs:
       - name: Get current git commit hash
         id: get-git-commit-hash
         run: |
-          echo "::set-output name=gitCommitHash::$(git rev-parse HEAD)"
+          echo "gitCommitHash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: ts-build-cache


### PR DESCRIPTION
### Changed
- Updated `::set-output` in favor of $GITHUB_OUTPUT.