### PR TITLE
Release @cuaklabs/iocuak-models@0.1.1

### DIFF
--- a/packages/iocuak-models/.npmignore
+++ b/packages/iocuak-models/.npmignore
@@ -9,8 +9,10 @@
 **/*.ts
 !lib/**/*.d.ts
 
+.eslintignore
 .eslintrc.js
+.lintstagedrc.json
+.prettierignore
 pnpm-lock.yaml
-project.json
-tsconfig.dev.json
+prettier.config.js
 tsconfig.json

--- a/packages/iocuak-models/CHANGELOG.md
+++ b/packages/iocuak-models/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-## [UNRELEASED]
+## 0.1.1 - 2022-12-28
 
 ### Added
 - Added `BindOptions`.
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-### 0.1.0 - 2022-11-09
+## 0.1.0 - 2022-11-09
 
 ### Added
 - Added `Binding` models.

--- a/packages/iocuak-models/package.json
+++ b/packages/iocuak-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-models",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Binding modules for iocuak",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## 0.1.1 - 2022-12-28

### Added
- Added `BindOptions`.

### Changed
- Updated dependencies to no longer require `reflect-metadata`.