### PR TITLE
Release @cuaklabs/iocuak-models-api@0.1.1

### DIFF
--- a/packages/iocuak-models-api/.npmignore
+++ b/packages/iocuak-models-api/.npmignore
@@ -1,6 +1,9 @@
 # Jest coverage report
 /coverage/
 
+# Stryker reports
+/reports
+
 # Turborepo files
 .turbo/
 
@@ -9,8 +12,11 @@
 **/*.ts
 !lib/**/*.d.ts
 
+.eslintignore
 .eslintrc.js
+.lintstagedrc.json
+.prettierignore
 pnpm-lock.yaml
-project.json
-tsconfig.dev.json
+stryker.conf.json
+prettier.config.js
 tsconfig.json

--- a/packages/iocuak-models-api/CHANGELOG.md
+++ b/packages/iocuak-models-api/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [UNRELEASED]
 
+
+
+
+## 0.1.1 - 2022-12-28
+
 ## Added
 - Added `BindOptionsApi`.
 
@@ -30,7 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-### 0.1.0 - 2022-11-09
+## 0.1.0 - 2022-11-09
 
 ### Added
 - Added `BaseBindingApi`.

--- a/packages/iocuak-models-api/jest.config.mjs
+++ b/packages/iocuak-models-api/jest.config.mjs
@@ -1,3 +1,0 @@
-import { tsGlobalConfig } from '@cuaklabs/iocuak-jest-config';
-
-export default tsGlobalConfig;

--- a/packages/iocuak-models-api/jest.js.config.mjs
+++ b/packages/iocuak-models-api/jest.js.config.mjs
@@ -1,3 +1,0 @@
-import { jsGlobalConfig } from '@cuaklabs/iocuak-jest-config';
-
-export default jsGlobalConfig;

--- a/packages/iocuak-models-api/package.json
+++ b/packages/iocuak-models-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-models-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Binding modules for iocuak",
   "main": "lib/index.js",
   "repository": {
@@ -49,11 +49,6 @@
     "build:clean": "rimraf lib",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",
-    "prebuild": "pnpm run build:clean",
-    "test": "jest --config=jest.config.mjs --runInBand",
-    "test:integration:js": "pnpm run test:js --selectProjects Integration",
-    "test:js": "jest --config=jest.js.config.mjs --runInBand",
-    "test:uncommitted": "pnpm run test --changedSince=HEAD",
-    "test:unit:js": "pnpm run test:js --selectProjects Unit"
+    "prebuild": "pnpm run build:clean"
   }
 }

--- a/packages/iocuak-models/CHANGELOG.md
+++ b/packages/iocuak-models/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+## [UNRELEASED]
+
+
+
+
 ## 0.1.1 - 2022-12-28
 
 ### Added


### PR DESCRIPTION
## 0.1.1 - 2022-12-28

## Added
- Added `BindOptionsApi`.

### Changed
- Updated dependencies to no longer require `reflect-metadata`.
