### PR TITLE
Release @cuaklabs/iocuak@0.4.0

### DIFF
--- a/packages/iocuak/.npmignore
+++ b/packages/iocuak/.npmignore
@@ -1,6 +1,9 @@
 # Jest coverage report
 /coverage/
 
+# Stryker reports
+/reports
+
 # Turborepo files
 .turbo/
 
@@ -9,8 +12,14 @@
 **/*.ts
 !lib/**/*.d.ts
 
+.eslintignore
 .eslintrc.js
+.lintstagedrc.json
+.prettierignore
+jest.config.mjs
+jest.config.stryker.mjs
+jest.js.config.mjs
 pnpm-lock.yaml
-project.json
-tsconfig.dev.json
+stryker.conf.json
+prettier.config.js
 tsconfig.json

--- a/packages/iocuak/CHANGELOG.md
+++ b/packages/iocuak/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [UNRELEASED]
 
+
+
+
+## 0.4.0 - 2022-12-28
+
 ### Added
 - Added `BindOptions`.
 

--- a/packages/iocuak/package.json
+++ b/packages/iocuak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Minimal inversion of control container inspired by InversifyJS (https://inversify.io/)",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## 0.4.0 - 2022-12-28

### Added
- Added `BindOptions`.

### Changed
- Updated dependencies require `reflect-metadata` as dev dependency.
- Updated dependencies with `@cuaklabs/iocuak-` internal libraries.
- Updated `BindService.bind` with options.
