### PR TITLE
Ignore `eslint-plugin-import` updates until a proper version is released

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
     "pnpm": "7"
   },
   "extends": ["config:base", ":disableRateLimiting"],
+  "ignoreDeps": ["eslint-plugin-import"],
   "rebaseWhen": "conflicted",
   "semanticCommits": "enabled",
   "schedule": [


### PR DESCRIPTION
### Changed
- Updated renovate bot config ignoring `eslint-plugin-import`.