### PR TITLE
Update Container to avoid loading duplicated ContainerModuleMetadata

### DIFF
--- a/.changeset/great-singers-perform.md
+++ b/.changeset/great-singers-perform.md
@@ -1,0 +1,5 @@
+---
+"@cuaklabs/iocuak": minor
+---
+
+Updated `Container` to avoid loading duplicated ContainerModuleMetadata

--- a/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.spec.ts
+++ b/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.spec.ts
@@ -3,10 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 jest.mock('@cuaklabs/iocuak-core');
 
 jest.mock('../../../binding/utils/api/convertBindingToBindingApi');
-jest.mock(
-  '../../../containerModuleMetadata/actions/api/convertToContainerModuleMetadata',
-);
 jest.mock('../../../binding/utils/api/convertToBindOptions');
+jest.mock(
+  '../../../containerModuleMetadata/calculations/api/buildContainerModuleMetadataArray',
+);
 
 import { Newable, ServiceId, Tag } from '@cuaklabs/iocuak-common';
 import {
@@ -21,7 +21,7 @@ import {
   ContainerModuleMetadata,
   createCreateInstanceTaskContext,
   LoadModuleMetadataTaskContext,
-  loadContainerModuleMetadata,
+  loadContainerModuleMetadataArray,
 } from '@cuaklabs/iocuak-core';
 import { Binding, BindOptions } from '@cuaklabs/iocuak-models';
 import {
@@ -36,7 +36,7 @@ import { ValueBindingFixtures } from '../../../binding/fixtures/domain/ValueBind
 import { convertBindingToBindingApi } from '../../../binding/utils/api/convertBindingToBindingApi';
 import { convertToBindOptions } from '../../../binding/utils/api/convertToBindOptions';
 import { ContainerModuleApi } from '../../../containerModule/models/api/ContainerModuleApi';
-import { convertToContainerModuleMetadata } from '../../../containerModuleMetadata/actions/api/convertToContainerModuleMetadata';
+import { buildContainerModuleMetadataArray } from '../../../containerModuleMetadata/calculations/api/buildContainerModuleMetadataArray';
 import { ContainerModuleMetadataApi } from '../../../containerModuleMetadata/models/api/ContainerModuleMetadataApi';
 import { ContainerService } from '../domain/ContainerService';
 import { ContainerServiceApiImplementation } from './ContainerServiceApiImplementation';
@@ -493,10 +493,10 @@ describe(ContainerServiceApiImplementation.name, () => {
         ).mockReturnValueOnce(loadModuleMetadataTaskContextFixture);
 
         (
-          convertToContainerModuleMetadata as jest.Mock<
-            typeof convertToContainerModuleMetadata
+          buildContainerModuleMetadataArray as jest.Mock<
+            typeof buildContainerModuleMetadataArray
           >
-        ).mockReturnValueOnce(containerModuleMetadataFixture);
+        ).mockReturnValueOnce([containerModuleMetadataFixture]);
 
         result = await containerServiceApiImplementation.loadMetadata(
           containerModuleMetadataApiFixture,
@@ -512,9 +512,9 @@ describe(ContainerServiceApiImplementation.name, () => {
         expect(containerRequestServiceMock.start).toHaveBeenCalledWith();
       });
 
-      it('should call convertToContainerModuleMetadata()', () => {
-        expect(convertToContainerModuleMetadata).toHaveBeenCalledTimes(1);
-        expect(convertToContainerModuleMetadata).toHaveBeenCalledWith(
+      it('should call buildContainerModuleMetadataArray()', () => {
+        expect(buildContainerModuleMetadataArray).toHaveBeenCalledTimes(1);
+        expect(buildContainerModuleMetadataArray).toHaveBeenCalledWith(
           containerModuleMetadataApiFixture,
         );
       });
@@ -539,10 +539,9 @@ describe(ContainerServiceApiImplementation.name, () => {
         );
       });
 
-      it('should call loadContainerModuleMetadata()', () => {
-        expect(loadContainerModuleMetadata).toHaveBeenCalledTimes(1);
-        expect(loadContainerModuleMetadata).toHaveBeenCalledWith(
-          containerModuleMetadataFixture,
+      it('should call loadContainerModuleMetadataArray()', () => {
+        expect(loadContainerModuleMetadataArray).toHaveBeenCalledTimes(1);
+        expect(loadContainerModuleMetadataArray).toHaveBeenCalledWith(
           loadModuleMetadataTaskContextFixture,
         );
       });

--- a/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.ts
+++ b/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.ts
@@ -8,8 +8,8 @@ import {
   ContainerModuleMetadata,
   createCreateInstanceTaskContext,
   LoadModuleMetadataTaskContext,
-  loadContainerModuleMetadata,
   TaskContextServices,
+  loadContainerModuleMetadataArray,
 } from '@cuaklabs/iocuak-core';
 import { Binding, BindOptions } from '@cuaklabs/iocuak-models';
 import { BindingApi, BindOptionsApi } from '@cuaklabs/iocuak-models-api';
@@ -17,7 +17,7 @@ import { BindingApi, BindOptionsApi } from '@cuaklabs/iocuak-models-api';
 import { convertBindingToBindingApi } from '../../../binding/utils/api/convertBindingToBindingApi';
 import { convertToBindOptions } from '../../../binding/utils/api/convertToBindOptions';
 import { ContainerModuleApi } from '../../../containerModule/models/api/ContainerModuleApi';
-import { convertToContainerModuleMetadata } from '../../../containerModuleMetadata/actions/api/convertToContainerModuleMetadata';
+import { buildContainerModuleMetadataArray } from '../../../containerModuleMetadata/calculations/api/buildContainerModuleMetadataArray';
 import { ContainerModuleMetadataApi } from '../../../containerModuleMetadata/models/api/ContainerModuleMetadataApi';
 import { BindValueOptionsApi } from '../../models/api/BindValueOptionsApi';
 import { ContainerService } from '../domain/ContainerService';
@@ -107,16 +107,16 @@ export class ContainerServiceApiImplementation implements ContainerServiceApi {
   ): Promise<void> {
     const requestId: symbol = this._containerService.request.start();
 
-    const containerModuleMetadata: ContainerModuleMetadata =
-      convertToContainerModuleMetadata(containerModuleMetadataApi);
+    const containerModuleMetadataArray: ContainerModuleMetadata[] =
+      buildContainerModuleMetadataArray(containerModuleMetadataApi);
 
     const context: LoadModuleMetadataTaskContext =
       new LoadModuleMetadataTaskContext(
         this.#createInstanceTaskContext(requestId),
-        [containerModuleMetadata],
+        containerModuleMetadataArray,
       );
 
-    await loadContainerModuleMetadata(containerModuleMetadata, context);
+    await loadContainerModuleMetadataArray(context);
 
     this._containerService.request.end(
       context.createInstanceTaskContext.requestId,


### PR DESCRIPTION
### Changed
- Updated `Container` to avoid loading duplicated `ContainerModuleMetadata`.