### PR TITLE
Release @cuaklabs/iocuak-models@0.1.2

### DIFF
--- a/packages/iocuak-models/CHANGELOG.md
+++ b/packages/iocuak-models/CHANGELOG.md
@@ -1,49 +1,31 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## 0.1.2 - 2023-02-05
 
-<!--
-## [UNRELEASED]
+### Patch Changes
 
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
-### Docs
--->
-
-
-
-
-## [UNRELEASED]
-
-
-
+- Updated dependencies [c4861bc]
+- Updated dependencies [42198a4]
+  - @cuaklabs/iocuak-common@0.2.0
+  - @cuaklabs/iocuak-reflect-metadata-utils@0.1.2
 
 ## 0.1.1 - 2022-12-28
 
 ### Added
+
 - Added `BindOptions`.
 
 ### Changed
+
 - Updated dependencies to no longer require `reflect-metadata`.
-
-
-
 
 ## 0.1.0 - 2022-11-09
 
 ### Added
+
 - Added `Binding` models.
 - Added `bindingReflectKey`.
 - Added `ClassMetadata`.
 - Added `classMetadataReflectKey`.
 - Added `getDefaultBindingScope`.
 - Added `getDefaultClassMetadata`.
-
-
-

--- a/packages/iocuak-models/package.json
+++ b/packages/iocuak-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-models",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Binding modules for iocuak",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## 0.1.2 - 2023-02-05

### Patch Changes

- Updated dependencies [c4861bc]
- Updated dependencies [42198a4]
  - @cuaklabs/iocuak-common@0.2.0
  - @cuaklabs/iocuak-reflect-metadata-utils@0.1.2
