### PR TITLE
Release @cuaklabs/iocuak-decorators@0.1.2

### DIFF
--- a/packages/iocuak-decorators/CHANGELOG.md
+++ b/packages/iocuak-decorators/CHANGELOG.md
@@ -1,45 +1,28 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## 0.1.2 - 2023-02-05
 
-<!--
-## [UNRELEASED]
+### Patch Changes
 
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security
-### Docs
--->
-
-
-
-
-## [UNRELEASED]
-
-
-
+- Updated dependencies [c4861bc]
+- Updated dependencies [42198a4]
+  - @cuaklabs/iocuak-common@0.2.0
+  - @cuaklabs/iocuak-models@0.1.2
+  - @cuaklabs/iocuak-models-api@0.1.2
+  - @cuaklabs/iocuak-reflect-metadata-utils@0.1.2
 
 ## 0.1.1 - 2022-12-28
 
 ### Changed
+
 - Updated `reflect-metadata` dependency to be dev dependency.
-
-
-
 
 ## 0.1.0 - 2022-11-09
 
 ### Added
+
 - Added `inject`.
 - Added `injectable`.
 - Added `injectFrom`.
 - Added `injectFromBase`.
 - Added `injectTag`.
-
-
-

--- a/packages/iocuak-decorators/package.json
+++ b/packages/iocuak-decorators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-decorators",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Binding modules for iocuak",
   "main": "lib/index.js",
   "repository": {

--- a/packages/iocuak-models-api/CHANGELOG.md
+++ b/packages/iocuak-models-api/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.2
+## 0.1.2 - 2023-02-05
 
 ### Patch Changes
 


### PR DESCRIPTION
## 0.1.2 - 2023-02-05

### Patch Changes

- Updated dependencies [c4861bc]
- Updated dependencies [42198a4]
  - @cuaklabs/iocuak-common@0.2.0
  - @cuaklabs/iocuak-models@0.1.2
  - @cuaklabs/iocuak-models-api@0.1.2
  - @cuaklabs/iocuak-reflect-metadata-utils@0.1.2