### PR TITLE
Improve container module metadata id generation

### DIFF
--- a/.changeset/nervous-rice-add.md
+++ b/.changeset/nervous-rice-add.md
@@ -1,0 +1,5 @@
+---
+"@cuaklabs/iocuak": patch
+---
+
+Updated `Container.loadMetadata()` with smarter metadata id generation in order to avoid id collisions.

--- a/packages/iocuak/src/containerModuleMetadata/calculations/api/buildContainerModuleContainerModuleMetadataId.spec.ts
+++ b/packages/iocuak/src/containerModuleMetadata/calculations/api/buildContainerModuleContainerModuleMetadataId.spec.ts
@@ -1,0 +1,49 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../../foundation/calculations/hashString');
+
+import { ContainerModuleApi } from '../../../containerModule/models/api/ContainerModuleApi';
+import { hashString } from '../../../foundation/calculations/hashString';
+import { buildContainerModuleContainerModuleMetadataId } from './buildContainerModuleContainerModuleMetadataId';
+
+describe(buildContainerModuleContainerModuleMetadataId.name, () => {
+  let containerModuleApiFixture: ContainerModuleApi;
+
+  beforeAll(() => {
+    containerModuleApiFixture = {
+      load: () => {
+        /* comment */ return undefined;
+      },
+    };
+  });
+
+  describe('when called', () => {
+    let hashFixture: string;
+    let result: unknown;
+
+    beforeAll(() => {
+      (hashString as jest.Mock<typeof hashString>).mockReturnValueOnce(
+        hashFixture,
+      );
+
+      result = buildContainerModuleContainerModuleMetadataId(
+        containerModuleApiFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call hashString()', () => {
+      expect(hashString).toHaveBeenCalledTimes(1);
+      expect(hashString).toHaveBeenCalledWith(
+        containerModuleApiFixture.load.toString(),
+      );
+    });
+
+    it('should return a ContainerModuleMetadaId', () => {
+      expect(result).toBe(hashFixture);
+    });
+  });
+});

--- a/packages/iocuak/src/containerModuleMetadata/calculations/api/buildContainerModuleContainerModuleMetadataId.ts
+++ b/packages/iocuak/src/containerModuleMetadata/calculations/api/buildContainerModuleContainerModuleMetadataId.ts
@@ -1,0 +1,12 @@
+import { ContainerModuleMetadataId } from '@cuaklabs/iocuak-common';
+
+import { ContainerModuleApi } from '../../../containerModule/models/api/ContainerModuleApi';
+import { hashString } from '../../../foundation/calculations/hashString';
+
+export function buildContainerModuleContainerModuleMetadataId(
+  containerModuleApi: ContainerModuleApi,
+): ContainerModuleMetadataId {
+  const stringifiedLoadFunction: string = containerModuleApi.load.toString();
+
+  return hashString(stringifiedLoadFunction);
+}

--- a/packages/iocuak/src/containerModuleMetadata/calculations/api/buildContainerModuleMetadataArray.spec.ts
+++ b/packages/iocuak/src/containerModuleMetadata/calculations/api/buildContainerModuleMetadataArray.spec.ts
@@ -1,9 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('./buildContainerModuleClassMetadata');
+jest.mock('./buildContainerModuleContainerModuleMetadataId');
 jest.mock('./buildContainerModuleFactoryMetadata');
 
-import { Newable } from '@cuaklabs/iocuak-common';
+import { ContainerModuleMetadataId, Newable } from '@cuaklabs/iocuak-common';
 import {
   ContainerModuleClassMetadata,
   ContainerModuleFactoryMetadata,
@@ -15,6 +16,7 @@ import { ContainerModuleMetadataApiMocks } from '../../mocks/models/api/Containe
 import { ContainerModuleClassMetadataApi } from '../../models/api/ContainerModuleClassMetadataApi';
 import { ContainerModuleFactoryMetadataApi } from '../../models/api/ContainerModuleFactoryMetadataApi';
 import { buildContainerModuleClassMetadata } from './buildContainerModuleClassMetadata';
+import { buildContainerModuleContainerModuleMetadataId } from './buildContainerModuleContainerModuleMetadataId';
 import { buildContainerModuleFactoryMetadata } from './buildContainerModuleFactoryMetadata';
 import { buildContainerModuleMetadataArray } from './buildContainerModuleMetadataArray';
 
@@ -81,14 +83,23 @@ describe(buildContainerModuleMetadataArray.name, () => {
     });
 
     describe('when called', () => {
+      let containerModuleMetadataIdFixture: ContainerModuleMetadataId;
       let containerModuleMetadataFixture: ContainerModuleFactoryMetadata;
 
       let result: unknown;
 
       beforeAll(() => {
+        containerModuleMetadataIdFixture = Symbol();
+
         containerModuleMetadataFixture = {
           [Symbol()]: Symbol(),
         } as unknown as ContainerModuleFactoryMetadata;
+
+        (
+          buildContainerModuleContainerModuleMetadataId as jest.Mock<
+            typeof buildContainerModuleContainerModuleMetadataId
+          >
+        ).mockReturnValueOnce(containerModuleMetadataIdFixture);
 
         (
           buildContainerModuleFactoryMetadata as jest.Mock<
@@ -105,11 +116,21 @@ describe(buildContainerModuleMetadataArray.name, () => {
         jest.clearAllMocks();
       });
 
+      it('should call buildContainerModuleContainerModuleMetadataId()', () => {
+        expect(
+          buildContainerModuleContainerModuleMetadataId,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildContainerModuleContainerModuleMetadataId,
+        ).toHaveBeenCalledWith(containerModuleMetadataApiFixture);
+      });
+
       it('should call buildContainerModuleFactoryMetadata()', () => {
         const expected: ContainerModuleFactoryMetadataApi = {
           factory: expect.any(Function) as unknown as (
             ...args: unknown[]
           ) => ContainerModuleApi | Promise<ContainerModuleApi>,
+          id: containerModuleMetadataIdFixture,
         };
 
         expect(buildContainerModuleFactoryMetadata).toHaveBeenCalledTimes(1);

--- a/packages/iocuak/src/containerModuleMetadata/calculations/api/buildContainerModuleMetadataArray.ts
+++ b/packages/iocuak/src/containerModuleMetadata/calculations/api/buildContainerModuleMetadataArray.ts
@@ -13,6 +13,7 @@ import { ContainerModuleFactoryMetadataApi } from '../../models/api/ContainerMod
 import { ContainerModuleMetadataApi } from '../../models/api/ContainerModuleMetadataApi';
 import { ContainerModuleMetadataBaseApi } from '../../models/api/ContainerModuleMetadataBaseApi';
 import { buildContainerModuleClassMetadata } from './buildContainerModuleClassMetadata';
+import { buildContainerModuleContainerModuleMetadataId } from './buildContainerModuleContainerModuleMetadataId';
 import { buildContainerModuleFactoryMetadata } from './buildContainerModuleFactoryMetadata';
 import { isContainerModuleClassMetadataApi } from './isContainerModuleClassMetadataApi';
 
@@ -47,6 +48,9 @@ function appendContainerModuleMetadataAndNested<TArgs extends unknown[]>(
       containerModuleMetadata = appendContainerModuleFactoryMetadataAndNested(
         {
           factory: () => containerModuleMetadataApi,
+          id: buildContainerModuleContainerModuleMetadataId(
+            containerModuleMetadataApi,
+          ),
         },
         containerModuleMetadataArray,
       );


### PR DESCRIPTION
### Added
- Added `buildContainerModuleContainerModuleMetadataId`.

### Changed
- Updated `buildContainerModuleMetadataArray` to build container module metadata id on top of `buildContainerModuleContainerModuleMetadataId`.