### PR TITLE
Provide both esm and cjs modules

### DIFF
--- a/.changeset/pretty-peaches-smell.md
+++ b/.changeset/pretty-peaches-smell.md
@@ -1,0 +1,5 @@
+---
+"@cuaklabs/iocuak-models-api": minor
+---
+
+Provided both `esm` and `cjs` modules.

--- a/packages/iocuak-models-api/.eslintrc.js
+++ b/packages/iocuak-models-api/.eslintrc.js
@@ -2,7 +2,7 @@
 module.exports = {
   extends: '@cuaklabs/eslint-config-iocuak',
   parserOptions: {
-    project: ['./tsconfig.json'],
+    project: ['./tsconfig.cjs.json'],
     tsconfigRootDir: __dirname,
   },
 };

--- a/packages/iocuak-models-api/.npmignore
+++ b/packages/iocuak-models-api/.npmignore
@@ -19,4 +19,5 @@
 pnpm-lock.yaml
 stryker.conf.json
 prettier.config.js
-tsconfig.json
+tsconfig.cjs.json
+tsconfig.esm.json

--- a/packages/iocuak-models-api/package.json
+++ b/packages/iocuak-models-api/package.json
@@ -2,7 +2,14 @@
   "name": "@cuaklabs/iocuak-models-api",
   "version": "0.1.2",
   "description": "Binding modules for iocuak",
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "exports": {
+    ".": {
+        "import": "./lib/esm/index.js",
+        "require": "./lib/cjs/index.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cuaklabs/iocuak.git"
@@ -45,7 +52,9 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --build tsconfig.json",
+    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec iocuak-ts-package-cjs ./lib/cjs",
+    "build:esm": "tsc --build tsconfig.esm.json && pnpm exec iocuak-ts-package-esm ./lib/esm",
     "build:clean": "rimraf lib",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",

--- a/packages/iocuak-models-api/tsconfig.cjs.json
+++ b/packages/iocuak-models-api/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "@cuaklabs/typescript-config-iocuak/tsconfig.base.cjs.json",
+  "compilerOptions": {
+    "outDir": "./lib/cjs",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/iocuak-models-api/tsconfig.esm.json
+++ b/packages/iocuak-models-api/tsconfig.esm.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "@cuaklabs/typescript-config-iocuak/tsconfig.base.cjs.json",
+  "extends": "@cuaklabs/typescript-config-iocuak/tsconfig.base.esm.json",
   "compilerOptions": {
-    "outDir": "./lib",
+    "outDir": "./lib/esm",
     "rootDir": "./src"
   },
   "include": ["src"]


### PR DESCRIPTION
### Changed
- Updated `iocuak-api-models`to provide both `cjs` and `esm` modules.