### PR TITLE
Provide both esm and cjs modules

### DIFF
--- a/.changeset/new-balloons-reply.md
+++ b/.changeset/new-balloons-reply.md
@@ -1,0 +1,5 @@
+---
+"@cuaklabs/iocuak-reflect-metadata-utils": minor
+---
+
+Provided both `esm` and `cjs` modules.

--- a/packages/iocuak-reflect-metadata-utils/.eslintrc.js
+++ b/packages/iocuak-reflect-metadata-utils/.eslintrc.js
@@ -2,7 +2,7 @@
 module.exports = {
   extends: '@cuaklabs/eslint-config-iocuak',
   parserOptions: {
-    project: ['./tsconfig.json'],
+    project: ['./tsconfig.cjs.json'],
     tsconfigRootDir: __dirname,
   },
 };

--- a/packages/iocuak-reflect-metadata-utils/.npmignore
+++ b/packages/iocuak-reflect-metadata-utils/.npmignore
@@ -22,4 +22,5 @@ jest.js.config.mjs
 pnpm-lock.yaml
 stryker.conf.json
 prettier.config.js
-tsconfig.json
+tsconfig.cjs.json
+tsconfig.esm.json

--- a/packages/iocuak-reflect-metadata-utils/jest.js.config.mjs
+++ b/packages/iocuak-reflect-metadata-utils/jest.js.config.mjs
@@ -1,5 +1,5 @@
 import { getJsGlobalConfig } from '@cuaklabs/iocuak-jest-config';
 
-const jsGlobalConfig = getJsGlobalConfig('./lib');
+const jsGlobalConfig = getJsGlobalConfig('./lib/cjs');
 
 export default jsGlobalConfig;

--- a/packages/iocuak-reflect-metadata-utils/package.json
+++ b/packages/iocuak-reflect-metadata-utils/package.json
@@ -2,7 +2,14 @@
   "name": "@cuaklabs/iocuak-reflect-metadata-utils",
   "version": "0.1.2",
   "description": "Metadata models for iocuak",
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "exports": {
+    ".": {
+        "import": "./lib/esm/index.js",
+        "require": "./lib/cjs/index.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cuaklabs/iocuak.git"
@@ -50,7 +57,9 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --build tsconfig.json",
+    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec iocuak-ts-package-cjs ./lib/cjs",
+    "build:esm": "tsc --build tsconfig.esm.json && pnpm exec iocuak-ts-package-esm ./lib/esm",
     "build:clean": "rimraf lib",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",

--- a/packages/iocuak-reflect-metadata-utils/tsconfig.cjs.json
+++ b/packages/iocuak-reflect-metadata-utils/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "@cuaklabs/typescript-config-iocuak/tsconfig.base.cjs.json",
+  "compilerOptions": {
+    "outDir": "./lib/cjs",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/iocuak-reflect-metadata-utils/tsconfig.esm.json
+++ b/packages/iocuak-reflect-metadata-utils/tsconfig.esm.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "@cuaklabs/typescript-config-iocuak/tsconfig.base.cjs.json",
+  "extends": "@cuaklabs/typescript-config-iocuak/tsconfig.base.esm.json",
   "compilerOptions": {
-    "outDir": "./lib",
+    "outDir": "./lib/esm",
     "rootDir": "./src"
   },
   "include": ["src"]


### PR DESCRIPTION
### Changed
- Updated `iocuak-reflect-metadata-utils` to provide both `cjs` and `esm` modules.