### PR TITLE
Add esm bundled modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "cucumberautocomplete.steps": [
-    "packages/*/lib/definitions/**/*.js"
+    "packages/*/lib/cjs/definitions/**/*.js"
   ],
   "cucumberautocomplete.strictGherkinCompletion": true,
   "eslint.workingDirectories": [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/cuaklabs/iocuak#readme",
   "devDependencies": {
-    "@changesets/cli": "^2.26.0",
+    "@changesets/cli": "2.26.0",
     "@commitlint/cli": "17.4.4",
     "@commitlint/config-conventional": "17.4.4",
     "@commitlint/prompt-cli": "17.4.4",

--- a/packages/iocuak-common/package.json
+++ b/packages/iocuak-common/package.json
@@ -6,8 +6,8 @@
   "module": "lib/esm/index.js",
   "exports": {
     ".": {
-        "import": "./lib/esm/index.js",
-        "require": "./lib/cjs/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "repository": {
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@jest/globals": "29.4.3",
+    "@rollup/plugin-typescript": "11.0.0",
     "@stryker-mutator/core": "6.4.1",
     "@stryker-mutator/jest-runner": "6.4.1",
     "@stryker-mutator/typescript-checker": "6.4.1",
@@ -41,6 +42,7 @@
     "jest": "29.4.3",
     "prettier": "2.8.4",
     "rimraf": "4.1.2",
+    "rollup": "3.15.0",
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
@@ -51,10 +53,11 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run bundle:esm",
     "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec iocuak-ts-package-cjs ./lib/cjs",
-    "build:esm": "tsc --build tsconfig.esm.json && pnpm exec iocuak-ts-package-esm ./lib/esm",
+    "build:esm": "pnpm run bundle:esm && pnpm exec iocuak-ts-package-esm ./lib/esm",
     "build:clean": "rimraf lib",
+    "bundle:esm": "pnpm exec rollup -c ./rollup.config.mjs",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",
     "prebuild": "pnpm run build:clean",

--- a/packages/iocuak-common/rollup.config.mjs
+++ b/packages/iocuak-common/rollup.config.mjs
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript';
+
+/** @type {!import("rollup").MergedRollupOptions[]} */
+export default [
+  {
+    input: './src/index.ts',
+    output: [
+      {
+        dir: './lib/esm',
+        format: 'esm',
+      },
+    ],
+    plugins: [typescript()],
+  },
+];

--- a/packages/iocuak-common/tsconfig.json
+++ b/packages/iocuak-common/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.cjs.json"
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/iocuak-core/package.json
+++ b/packages/iocuak-core/package.json
@@ -6,8 +6,8 @@
   "module": "lib/esm/index.js",
   "exports": {
     ".": {
-        "import": "./lib/esm/index.js",
-        "require": "./lib/cjs/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "repository": {
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@jest/globals": "29.4.3",
+    "@rollup/plugin-typescript": "11.0.0",
     "@stryker-mutator/core": "6.4.1",
     "@stryker-mutator/jest-runner": "6.4.1",
     "@stryker-mutator/typescript-checker": "6.4.1",
@@ -46,6 +47,7 @@
     "jest": "29.4.3",
     "prettier": "2.8.4",
     "rimraf": "4.1.2",
+    "rollup": "3.15.0",
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
@@ -55,10 +57,11 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run bundle:esm",
     "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec iocuak-ts-package-cjs ./lib/cjs",
-    "build:esm": "tsc --build tsconfig.esm.json && pnpm exec iocuak-ts-package-esm ./lib/esm",
+    "build:esm": "pnpm run bundle:esm && pnpm exec iocuak-ts-package-esm ./lib/esm",
     "build:clean": "rimraf lib",
+    "bundle:esm": "pnpm exec rollup -c ./rollup.config.mjs",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",
     "prebuild": "pnpm run build:clean",

--- a/packages/iocuak-core/rollup.config.mjs
+++ b/packages/iocuak-core/rollup.config.mjs
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript';
+
+/** @type {!import("rollup").MergedRollupOptions[]} */
+export default [
+  {
+    input: './src/index.ts',
+    output: [
+      {
+        dir: './lib/esm',
+        format: 'esm',
+      },
+    ],
+    plugins: [typescript()],
+  },
+];

--- a/packages/iocuak-core/tsconfig.json
+++ b/packages/iocuak-core/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.cjs.json"
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/iocuak-decorators/package.json
+++ b/packages/iocuak-decorators/package.json
@@ -6,8 +6,8 @@
   "module": "lib/esm/index.js",
   "exports": {
     ".": {
-        "import": "./lib/esm/index.js",
-        "require": "./lib/cjs/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "repository": {
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@jest/globals": "29.4.3",
+    "@rollup/plugin-typescript": "11.0.0",
     "@stryker-mutator/core": "6.4.1",
     "@stryker-mutator/jest-runner": "6.4.1",
     "@stryker-mutator/typescript-checker": "6.4.1",
@@ -48,6 +49,7 @@
     "prettier": "2.8.4",
     "reflect-metadata": "0.1.13",
     "rimraf": "4.1.2",
+    "rollup": "3.15.0",
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
@@ -58,10 +60,11 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run bundle:esm",
     "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec iocuak-ts-package-cjs ./lib/cjs",
-    "build:esm": "tsc --build tsconfig.esm.json && pnpm exec iocuak-ts-package-esm ./lib/esm",
+    "build:esm": "pnpm run bundle:esm && pnpm exec iocuak-ts-package-esm ./lib/esm",
     "build:clean": "rimraf lib",
+    "bundle:esm": "pnpm exec rollup -c ./rollup.config.mjs",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",
     "prebuild": "pnpm run build:clean",

--- a/packages/iocuak-decorators/rollup.config.mjs
+++ b/packages/iocuak-decorators/rollup.config.mjs
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript';
+
+/** @type {!import("rollup").MergedRollupOptions[]} */
+export default [
+  {
+    input: './src/index.ts',
+    output: [
+      {
+        dir: './lib/esm',
+        format: 'esm',
+      },
+    ],
+    plugins: [typescript()],
+  },
+];

--- a/packages/iocuak-decorators/tsconfig.json
+++ b/packages/iocuak-decorators/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.cjs.json"
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/iocuak-models-api/package.json
+++ b/packages/iocuak-models-api/package.json
@@ -6,8 +6,8 @@
   "module": "lib/esm/index.js",
   "exports": {
     ".": {
-        "import": "./lib/esm/index.js",
-        "require": "./lib/cjs/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "repository": {
@@ -30,7 +30,7 @@
     "@cuaklabs/iocuak-models": "workspace:*"
   },
   "devDependencies": {
-    "@jest/globals": "29.4.3",
+    "@rollup/plugin-typescript": "11.0.0",
     "@types/node": "18.14.0",
     "@typescript-eslint/eslint-plugin": "5.52.0",
     "@typescript-eslint/parser": "5.52.0",
@@ -42,6 +42,7 @@
     "jest": "29.4.3",
     "prettier": "2.8.4",
     "rimraf": "4.1.2",
+    "rollup": "3.15.0",
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
@@ -52,10 +53,11 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run bundle:esm",
     "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec iocuak-ts-package-cjs ./lib/cjs",
-    "build:esm": "tsc --build tsconfig.esm.json && pnpm exec iocuak-ts-package-esm ./lib/esm",
+    "build:esm": "pnpm run bundle:esm && pnpm exec iocuak-ts-package-esm ./lib/esm",
     "build:clean": "rimraf lib",
+    "bundle:esm": "pnpm exec rollup -c ./rollup.config.mjs",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",
     "prebuild": "pnpm run build:clean"

--- a/packages/iocuak-models-api/rollup.config.mjs
+++ b/packages/iocuak-models-api/rollup.config.mjs
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript';
+
+/** @type {!import("rollup").MergedRollupOptions[]} */
+export default [
+  {
+    input: './src/index.ts',
+    output: [
+      {
+        dir: './lib/esm',
+        format: 'esm',
+      },
+    ],
+    plugins: [typescript()],
+  },
+];

--- a/packages/iocuak-models-api/tsconfig.json
+++ b/packages/iocuak-models-api/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.cjs.json"
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/iocuak-models/package.json
+++ b/packages/iocuak-models/package.json
@@ -6,8 +6,8 @@
   "module": "lib/esm/index.js",
   "exports": {
     ".": {
-        "import": "./lib/esm/index.js",
-        "require": "./lib/cjs/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "repository": {
@@ -30,6 +30,7 @@
     "@cuaklabs/iocuak-reflect-metadata-utils": "workspace:*"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "11.0.0",
     "@typescript-eslint/eslint-plugin": "5.52.0",
     "@typescript-eslint/parser": "5.52.0",
     "eslint": "8.34.0",
@@ -39,6 +40,7 @@
     "eslint-plugin-prettier": "4.2.1",
     "prettier": "2.8.4",
     "rimraf": "4.1.2",
+    "rollup": "3.15.0",
     "typescript": "4.9.5"
   },
   "homepage": "https://github.com/cuaklabs/iocuak/tree/master/packages/iocuak/tree/master/packages/iocuak-models#readme",
@@ -47,10 +49,11 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run bundle:esm",
     "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec iocuak-ts-package-cjs ./lib/cjs",
-    "build:esm": "tsc --build tsconfig.esm.json && pnpm exec iocuak-ts-package-esm ./lib/esm",
+    "build:esm": "pnpm run bundle:esm && pnpm exec iocuak-ts-package-esm ./lib/esm",
     "build:clean": "rimraf lib",
+    "bundle:esm": "pnpm exec rollup -c ./rollup.config.mjs",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",
     "prebuild": "pnpm run build:clean"

--- a/packages/iocuak-models/rollup.config.mjs
+++ b/packages/iocuak-models/rollup.config.mjs
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript';
+
+/** @type {!import("rollup").MergedRollupOptions[]} */
+export default [
+  {
+    input: './src/index.ts',
+    output: [
+      {
+        dir: './lib/esm',
+        format: 'esm',
+      },
+    ],
+    plugins: [typescript()],
+  },
+];

--- a/packages/iocuak-models/tsconfig.json
+++ b/packages/iocuak-models/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.cjs.json"
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/iocuak-reflect-metadata-utils/package.json
+++ b/packages/iocuak-reflect-metadata-utils/package.json
@@ -6,8 +6,8 @@
   "module": "lib/esm/index.js",
   "exports": {
     ".": {
-        "import": "./lib/esm/index.js",
-        "require": "./lib/cjs/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "repository": {
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@jest/globals": "29.4.3",
+    "@rollup/plugin-typescript": "11.0.0",
     "@stryker-mutator/core": "6.4.1",
     "@stryker-mutator/jest-runner": "6.4.1",
     "@stryker-mutator/typescript-checker": "6.4.1",
@@ -44,6 +45,7 @@
     "jest": "29.4.3",
     "prettier": "2.8.4",
     "rimraf": "4.1.2",
+    "rollup": "3.15.0",
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
@@ -57,10 +59,11 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run bundle:esm",
     "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec iocuak-ts-package-cjs ./lib/cjs",
-    "build:esm": "tsc --build tsconfig.esm.json && pnpm exec iocuak-ts-package-esm ./lib/esm",
+    "build:esm": "pnpm run bundle:esm && pnpm exec iocuak-ts-package-esm ./lib/esm",
     "build:clean": "rimraf lib",
+    "bundle:esm": "pnpm exec rollup -c ./rollup.config.mjs",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",
     "prebuild": "pnpm run build:clean",

--- a/packages/iocuak-reflect-metadata-utils/rollup.config.mjs
+++ b/packages/iocuak-reflect-metadata-utils/rollup.config.mjs
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript';
+
+/** @type {!import("rollup").MergedRollupOptions[]} */
+export default [
+  {
+    input: './src/index.ts',
+    output: [
+      {
+        dir: './lib/esm',
+        format: 'esm',
+      },
+    ],
+    plugins: [typescript()],
+  },
+];

--- a/packages/iocuak-reflect-metadata-utils/tsconfig.json
+++ b/packages/iocuak-reflect-metadata-utils/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.cjs.json"
+  "extends": "./tsconfig.esm.json"
 }

--- a/packages/iocuak/package.json
+++ b/packages/iocuak/package.json
@@ -6,8 +6,8 @@
   "module": "lib/esm/index.js",
   "exports": {
     ".": {
-        "import": "./lib/esm/index.js",
-        "require": "./lib/cjs/index.js"
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
     }
   },
   "repository": {
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@jest/globals": "29.4.3",
+    "@rollup/plugin-typescript": "11.0.0",
     "@stryker-mutator/core": "6.4.1",
     "@stryker-mutator/jest-runner": "6.4.1",
     "@stryker-mutator/typescript-checker": "6.4.1",
@@ -50,6 +51,7 @@
     "prettier": "2.8.4",
     "reflect-metadata": "0.1.13",
     "rimraf": "4.1.2",
+    "rollup": "3.15.0",
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
@@ -60,10 +62,11 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build": "pnpm run build:cjs && pnpm run build:esm && pnpm run bundle:esm",
     "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec iocuak-ts-package-cjs ./lib/cjs",
-    "build:esm": "tsc --build tsconfig.esm.json && pnpm exec iocuak-ts-package-esm ./lib/esm",
+    "build:esm": "pnpm run bundle:esm && pnpm exec iocuak-ts-package-esm ./lib/esm",
     "build:clean": "rimraf lib",
+    "bundle:esm": "pnpm exec rollup -c ./rollup.config.mjs",
     "format": "prettier --write ./src/**/*.ts",
     "lint": "eslint --ext ts --ignore-path .gitignore ./src",
     "prebuild": "pnpm run build:clean",

--- a/packages/iocuak/rollup.config.mjs
+++ b/packages/iocuak/rollup.config.mjs
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript';
+
+/** @type {!import("rollup").MergedRollupOptions[]} */
+export default [
+  {
+    input: './src/index.ts',
+    output: [
+      {
+        dir: './lib/esm',
+        format: 'esm',
+      },
+    ],
+    plugins: [typescript()],
+  },
+];

--- a/packages/iocuak/tsconfig.json
+++ b/packages/iocuak/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.cjs.json"
+  "extends": "./tsconfig.esm.json"
 }


### PR DESCRIPTION
### Changed

- Provided `esm` bundled modules in order to allow NodeJs to properly resolve modules when targeting `esm`. This solution was chosen among many others with the following goals in mind:
  - Do not break `ts-node` compatibility. This allows to keep a decent developer experience with nice debugging capabilities and git hooks able to test changed files in a reasonable amount of time.
  - Provide compatibility with NodeJs.
  - Keep CommonJS modules.