### PR TITLE
Revert turbo and ignore updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     "pnpm": "7"
   },
   "extends": ["config:base", ":disableRateLimiting"],
-  "ignoreDeps": ["eslint-plugin-import"],
+  "ignoreDeps": ["eslint-plugin-import", "turbo"],
   "rebaseWhen": "conflicted",
   "semanticCommits": "enabled",
   "schedule": [

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "husky": "8.0.3",
     "lint-staged": "13.1.2",
     "reflect-metadata": "0.1.13",
-    "turbo": "1.8.1"
+    "turbo": "1.7.4"
   }
 }


### PR DESCRIPTION
### Changed
- Updated turbo to `1.7.4`.
- Updated renovatebot ignored dependencies with `turbo`.

This change should be temporally applied until https://github.com/vercel/turbo/issues/3896 is solved