### PR TITLE
Exclude turbo from renovate ignored packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     "pnpm": "7"
   },
   "extends": ["config:base", ":disableRateLimiting"],
-  "ignoreDeps": ["eslint-plugin-import", "turbo"],
+  "ignoreDeps": ["eslint-plugin-import"],
   "rebaseWhen": "conflicted",
   "semanticCommits": "enabled",
   "schedule": [

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "husky": "8.0.3",
     "lint-staged": "13.1.2",
     "reflect-metadata": "0.1.13",
-    "turbo": "1.7.4"
+    "turbo": "1.8.2"
   }
 }


### PR DESCRIPTION
### Changed
- Updated `renovatebot` config to no longer ignore `turbo` updates.
- Updated `turbo` to `1.8.2`.