### PR TITLE
Supress e2e bundle warns

### DIFF
--- a/packages/iocuak-e2e/rollup.config.mjs
+++ b/packages/iocuak-e2e/rollup.config.mjs
@@ -9,6 +9,7 @@ export default [
       {
         dir: './lib/esm',
         format: 'esm',
+        sourcemap: true,
       },
     ],
     plugins: [multi(), typescript()],

--- a/packages/iocuak-e2e/rollup.config.mjs
+++ b/packages/iocuak-e2e/rollup.config.mjs
@@ -1,6 +1,17 @@
 import multi from '@rollup/plugin-multi-entry';
 import typescript from '@rollup/plugin-typescript';
 
+const TS_LIB_WARN_MESSAGE =
+  "@rollup/plugin-typescript TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.";
+
+/**
+ * @param {!import("rollup").RollupLog} warning
+ * @returns boolean
+ */
+function isTsLibRequiredWarning(warning) {
+  return warning.message === TS_LIB_WARN_MESSAGE;
+}
+
 /** @type {!import("rollup").MergedRollupOptions[]} */
 export default [
   {
@@ -12,6 +23,11 @@ export default [
       'sinon-chai',
     ],
     input: './src/**/*.ts',
+    onwarn: (warning, defaultHandler) => {
+      if (!isTsLibRequiredWarning(warning)) {
+        defaultHandler(warning);
+      }
+    },
     output: [
       {
         dir: './lib/esm',

--- a/packages/iocuak-e2e/rollup.config.mjs
+++ b/packages/iocuak-e2e/rollup.config.mjs
@@ -4,6 +4,13 @@ import typescript from '@rollup/plugin-typescript';
 /** @type {!import("rollup").MergedRollupOptions[]} */
 export default [
   {
+    external: [
+      '@cuaklabs/iocuak',
+      '@cucumber/cucumber',
+      'chai',
+      'sinon',
+      'sinon-chai',
+    ],
     input: './src/**/*.ts',
     output: [
       {


### PR DESCRIPTION
### Changed
- Updated `iocuak-e2e` rollup config with external dependencies, missing options and a handler to supress wrong warnings.