### PR TITLE
Release iocuak-common@0.3.0

### DIFF
--- a/.changeset/light-squids-end.md
+++ b/.changeset/light-squids-end.md
@@ -1,5 +1,0 @@
----
-"@cuaklabs/iocuak-common": minor
----
-
-Provide both `esm` and `cjs` modules.

--- a/packages/iocuak-common/.npmignore
+++ b/packages/iocuak-common/.npmignore
@@ -7,9 +7,11 @@
 # Turborepo files
 .turbo/
 
+**/*.js.map
 **/*.spec.js
 **/*.spec.js.map
 **/*.ts
+**/*.ts.map
 !lib/**/*.d.ts
 
 .eslintignore
@@ -22,6 +24,7 @@ jest.js.config.mjs
 pnpm-lock.yaml
 stryker.conf.json
 prettier.config.js
+rollup.config.mjs
 tsconfig.cjs.json
 tsconfig.esm.json
 tsconfig.json

--- a/packages/iocuak-common/CHANGELOG.md
+++ b/packages/iocuak-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0 - 2023-02-24
+
+### Minor Changes
+
+- 68e1657: Provide both `esm` and `cjs` modules.
+
 ## 0.2.0 - 2023-02-05
 
 ### Minor Changes

--- a/packages/iocuak-common/package.json
+++ b/packages/iocuak-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-common",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Common models for iocuak",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## 0.3.0 - 2023-02-24

### Minor Changes

- 68e1657: Provide both `esm` and `cjs` modules.