### PR TITLE
Release @cuaklabs/iocuak-models@0.2.0

### DIFF
--- a/.changeset/violet-cats-tease.md
+++ b/.changeset/violet-cats-tease.md
@@ -1,5 +1,0 @@
----
-"@cuaklabs/iocuak-models": minor
----
-
-Provided both `esm` and `cjs` modules.

--- a/packages/iocuak-models/.npmignore
+++ b/packages/iocuak-models/.npmignore
@@ -4,9 +4,11 @@
 # Turborepo files
 .turbo/
 
+**/*.js.map
 **/*.spec.js
 **/*.spec.js.map
 **/*.ts
+**/*.ts.map
 !lib/**/*.d.ts
 
 .eslintignore
@@ -15,6 +17,7 @@
 .prettierignore
 pnpm-lock.yaml
 prettier.config.js
+rollup.config.mjs
 tsconfig.cjs.json
 tsconfig.esm.json
 tsconfig.json

--- a/packages/iocuak-models/CHANGELOG.md
+++ b/packages/iocuak-models/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.0 - 2023-02-24
+
+### Minor Changes
+
+- d69f4d4: Provided both `esm` and `cjs` modules.
+
+### Patch Changes
+
+- Updated dependencies [68e1657]
+- Updated dependencies [e7107eb]
+  - @cuaklabs/iocuak-common@0.3.0
+  - @cuaklabs/iocuak-reflect-metadata-utils@0.2.0
+
 ## 0.1.2 - 2023-02-05
 
 ### Patch Changes

--- a/packages/iocuak-models/package.json
+++ b/packages/iocuak-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-models",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Binding modules for iocuak",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## 0.2.0 - 2023-02-24

### Minor Changes

- d69f4d4: Provided both `esm` and `cjs` modules.

### Patch Changes

- Updated dependencies [68e1657]
- Updated dependencies [e7107eb]
  - @cuaklabs/iocuak-common@0.3.0
  - @cuaklabs/iocuak-reflect-metadata-utils@0.2.0