### PR TITLE
Release @cuaklabs/iocuak-models-api@0.2.0

### DIFF
--- a/.changeset/pretty-peaches-smell.md
+++ b/.changeset/pretty-peaches-smell.md
@@ -1,5 +1,0 @@
----
-"@cuaklabs/iocuak-models-api": minor
----
-
-Provided both `esm` and `cjs` modules.

--- a/.changeset/tall-hotels-rest.md
+++ b/.changeset/tall-hotels-rest.md
@@ -1,5 +1,0 @@
----
-"@cuaklabs/iocuak-decorators": minor
----
-
-Provided both `esm` and `cjs` modules.

--- a/packages/iocuak-models-api/.npmignore
+++ b/packages/iocuak-models-api/.npmignore
@@ -7,9 +7,11 @@
 # Turborepo files
 .turbo/
 
+**/*.js.map
 **/*.spec.js
 **/*.spec.js.map
 **/*.ts
+**/*.ts.map
 !lib/**/*.d.ts
 
 .eslintignore
@@ -19,6 +21,7 @@
 pnpm-lock.yaml
 stryker.conf.json
 prettier.config.js
+rollup.config.mjs
 tsconfig.cjs.json
 tsconfig.esm.json
 tsconfig.json

--- a/packages/iocuak-models-api/CHANGELOG.md
+++ b/packages/iocuak-models-api/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.0 - 2023-02-24
+
+### Minor Changes
+
+- 50222df: Provided both `esm` and `cjs` modules.
+
+### Patch Changes
+
+- Updated dependencies [68e1657]
+- Updated dependencies [d69f4d4]
+  - @cuaklabs/iocuak-common@0.3.0
+  - @cuaklabs/iocuak-models@0.2.0
+
 ## 0.1.2 - 2023-02-05
 
 ### Patch Changes

--- a/packages/iocuak-models-api/package.json
+++ b/packages/iocuak-models-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-models-api",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Binding modules for iocuak",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## 0.2.0 - 2023-02-24

### Minor Changes

- 50222df: Provided both `esm` and `cjs` modules.

### Patch Changes

- Updated dependencies [68e1657]
- Updated dependencies [d69f4d4]
  - @cuaklabs/iocuak-common@0.3.0
  - @cuaklabs/iocuak-models@0.2.0