### PR TITLE
Release @cuaklabs/decorators@0.2.0

### DIFF
--- a/packages/iocuak-decorators/.npmignore
+++ b/packages/iocuak-decorators/.npmignore
@@ -7,9 +7,11 @@
 # Turborepo files
 .turbo/
 
+**/*.js.map
 **/*.spec.js
 **/*.spec.js.map
 **/*.ts
+**/*.ts.map
 !lib/**/*.d.ts
 
 .eslintignore
@@ -20,6 +22,7 @@ jest.config.mjs
 jest.config.stryker.mjs
 jest.js.config.mjs
 pnpm-lock.yaml
+rollup.config.mjs
 stryker.conf.json
 prettier.config.js
 tsconfig.cjs.json

--- a/packages/iocuak-decorators/CHANGELOG.md
+++ b/packages/iocuak-decorators/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.2.0 - 2023-02-24
+
+### Minor Changes
+
+- 8db4462: Provided both `esm` and `cjs` modules.
+
+### Patch Changes
+
+- Updated dependencies [68e1657]
+- Updated dependencies [e7107eb]
+- Updated dependencies [50222df]
+- Updated dependencies [d69f4d4]
+  - @cuaklabs/iocuak-common@0.3.0
+  - @cuaklabs/iocuak-reflect-metadata-utils@0.2.0
+  - @cuaklabs/iocuak-models-api@0.2.0
+  - @cuaklabs/iocuak-models@0.2.0
+
 ## 0.1.2 - 2023-02-05
 
 ### Patch Changes

--- a/packages/iocuak-decorators/package.json
+++ b/packages/iocuak-decorators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-decorators",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Binding modules for iocuak",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## 0.2.0 - 2023-02-24

### Minor Changes

- 8db4462: Provided both `esm` and `cjs` modules.

### Patch Changes

- Updated dependencies [68e1657]
- Updated dependencies [e7107eb]
- Updated dependencies [50222df]
- Updated dependencies [d69f4d4]
  - @cuaklabs/iocuak-common@0.3.0
  - @cuaklabs/iocuak-reflect-metadata-utils@0.2.0
  - @cuaklabs/iocuak-models-api@0.2.0
  - @cuaklabs/iocuak-models@0.2.0