### PR TITLE
Release @cuaklabs/iocuak-core@0.3.0

### DIFF
--- a/.changeset/quick-days-grow.md
+++ b/.changeset/quick-days-grow.md
@@ -1,5 +1,0 @@
----
-"@cuaklabs/iocuak-core": minor
----
-
-Provided both `esm` and `cjs` modules.

--- a/packages/iocuak-core/.npmignore
+++ b/packages/iocuak-core/.npmignore
@@ -7,9 +7,11 @@
 # Turborepo files
 .turbo/
 
+**/*.js.map
 **/*.spec.js
 **/*.spec.js.map
 **/*.ts
+**/*.ts.map
 !lib/**/*.d.ts
 
 .eslintignore
@@ -20,6 +22,7 @@ jest.config.mjs
 jest.config.stryker.mjs
 jest.js.config.mjs
 pnpm-lock.yaml
+rollup.config.mjs
 stryker.conf.json
 prettier.config.js
 tsconfig.cjs.json

--- a/packages/iocuak-core/CHANGELOG.md
+++ b/packages/iocuak-core/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.3.0 - 2023-02-24
+
+### Minor Changes
+
+- 66481f6: Provided both `esm` and `cjs` modules.
+
+### Patch Changes
+
+- Updated dependencies [68e1657]
+- Updated dependencies [e7107eb]
+- Updated dependencies [d69f4d4]
+  - @cuaklabs/iocuak-common@0.3.0
+  - @cuaklabs/iocuak-reflect-metadata-utils@0.2.0
+  - @cuaklabs/iocuak-models@0.2.0
+
 ## 0.2.0 - 2023-02-05
 
 ### Minor Changes

--- a/packages/iocuak-core/package.json
+++ b/packages/iocuak-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The hexagonal architecture framework",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## 0.3.0 - 2023-02-24

### Minor Changes

- 66481f6: Provided both `esm` and `cjs` modules.

### Patch Changes

- Updated dependencies [68e1657]
- Updated dependencies [e7107eb]
- Updated dependencies [d69f4d4]
  - @cuaklabs/iocuak-common@0.3.0
  - @cuaklabs/iocuak-reflect-metadata-utils@0.2.0
  - @cuaklabs/iocuak-models@0.2.0