### PR TITLE
Release @cuaklabs/iocuak@0.6.0

### DIFF
--- a/.changeset/nervous-rice-add.md
+++ b/.changeset/nervous-rice-add.md
@@ -1,5 +1,0 @@
----
-"@cuaklabs/iocuak": patch
----
-
-Updated `Container.loadMetadata()` with smarter metadata id generation in order to avoid id collisions.

--- a/.changeset/six-walls-remember.md
+++ b/.changeset/six-walls-remember.md
@@ -1,5 +1,0 @@
----
-"@cuaklabs/iocuak": minor
----
-
-Provided both `esm` and `cjs` modules.

--- a/packages/iocuak/.npmignore
+++ b/packages/iocuak/.npmignore
@@ -7,9 +7,11 @@
 # Turborepo files
 .turbo/
 
+**/*.js.map
 **/*.spec.js
 **/*.spec.js.map
 **/*.ts
+**/*.ts.map
 !lib/**/*.d.ts
 
 .eslintignore
@@ -20,6 +22,7 @@ jest.config.mjs
 jest.config.stryker.mjs
 jest.js.config.mjs
 pnpm-lock.yaml
+rollup.config.mjs
 stryker.conf.json
 prettier.config.js
 tsconfig.cjs.json

--- a/packages/iocuak/CHANGELOG.md
+++ b/packages/iocuak/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.6.0 - 2023-02-24
+
+### Minor Changes
+
+- 255298a: Provided both `esm` and `cjs` modules.
+
+### Patch Changes
+
+- f6c2f25: Updated `Container.loadMetadata()` with smarter metadata id generation in order to avoid id collisions.
+- Updated dependencies [68e1657]
+- Updated dependencies [50222df]
+- Updated dependencies [66481f6]
+- Updated dependencies [8db4462]
+- Updated dependencies [d69f4d4]
+  - @cuaklabs/iocuak-common@0.3.0
+  - @cuaklabs/iocuak-models-api@0.2.0
+  - @cuaklabs/iocuak-core@0.3.0
+  - @cuaklabs/iocuak-decorators@0.2.0
+  - @cuaklabs/iocuak-models@0.2.0
+
 ## 0.5.0 - 2023-02-05
 
 ### Minor Changes

--- a/packages/iocuak/package.json
+++ b/packages/iocuak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Minimal inversion of control container inspired by InversifyJS (https://inversify.io/)",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## 0.6.0 - 2023-02-24

### Minor Changes

- 255298a: Provided both `esm` and `cjs` modules.

### Patch Changes

- f6c2f25: Updated `Container.loadMetadata()` with smarter metadata id generation in order to avoid id collisions.
- Updated dependencies [68e1657]
- Updated dependencies [50222df]
- Updated dependencies [66481f6]
- Updated dependencies [8db4462]
- Updated dependencies [d69f4d4]
  - @cuaklabs/iocuak-common@0.3.0
  - @cuaklabs/iocuak-models-api@0.2.0
  - @cuaklabs/iocuak-core@0.3.0
  - @cuaklabs/iocuak-decorators@0.2.0
  - @cuaklabs/iocuak-models@0.2.0