### PR TITLE
Release @cuaklabs/iocuak-core@0.3.1

### DIFF
--- a/.changeset/spicy-planes-grin.md
+++ b/.changeset/spicy-planes-grin.md
@@ -1,5 +1,0 @@
----
-"@cuaklabs/iocuak-core": patch
----
-
-Updated `ContainerModuleMetadata` arguments to be `any[]` by default.

--- a/packages/iocuak-core/CHANGELOG.md
+++ b/packages/iocuak-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1
+
+### Patch Changes
+
+- e80c8c7: Updated `ContainerModuleMetadata` arguments to be `any[]` by default.
+
 ## 0.3.0 - 2023-02-24
 
 ### Minor Changes

--- a/packages/iocuak-core/CHANGELOG.md
+++ b/packages/iocuak-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.1
+## 0.3.1 - 2023-02-27
 
 ### Patch Changes
 

--- a/packages/iocuak-core/package.json
+++ b/packages/iocuak-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak-core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The hexagonal architecture framework",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## 0.3.1 - 2023-02-27

### Patch Changes

- e80c8c7: Updated `ContainerModuleMetadata` arguments to be `any[]` by default.