### PR TITLE
Release @cuaklabs/iocuak@0.6.1

### DIFF
--- a/.changeset/clever-peas-camp.md
+++ b/.changeset/clever-peas-camp.md
@@ -1,5 +1,0 @@
----
-"@cuaklabs/iocuak": patch
----
-
-Updated `ContainerModuleMetadata` arguments to be `any[]` by default.

--- a/packages/iocuak/CHANGELOG.md
+++ b/packages/iocuak/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.1 - 2023-02-27
+
+### Patch Changes
+
+- c9edfc3: Updated `ContainerModuleMetadata` arguments to be `any[]` by default.
+- Updated dependencies [e80c8c7]
+  - @cuaklabs/iocuak-core@0.3.1
+
 ## 0.6.0 - 2023-02-24
 
 ### Minor Changes

--- a/packages/iocuak/package.json
+++ b/packages/iocuak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Minimal inversion of control container inspired by InversifyJS (https://inversify.io/)",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
## 0.6.1 - 2023-02-27

### Patch Changes

- c9edfc3: Updated `ContainerModuleMetadata` arguments to be `any[]` by default.
- Updated dependencies [e80c8c7]
  - @cuaklabs/iocuak-core@0.3.1