### PR TITLE
Revert turbo and blacklist its updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
       "groupName": "auto merge on patch or minor",
       "automerge": true,
       "matchUpdateTypes": ["patch", "minor"],
-      "excludePackageNames": ["typescript"]
+      "excludePackageNames": ["typescript", "turbo"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "husky": "8.0.3",
     "lint-staged": "13.2.0",
     "reflect-metadata": "0.1.13",
-    "turbo": "1.8.7"
+    "turbo": "1.8.6"
   }
 }


### PR DESCRIPTION
### Changed
- Reverted `turbo` to `1.8.6`.
- Updated auto merged dependency updates without `turbo`.